### PR TITLE
fixed creating unique permissions for on-prem enviroments

### DIFF
--- a/src/Acceleratio.SPDG.Generator/AD.cs
+++ b/src/Acceleratio.SPDG.Generator/AD.cs
@@ -86,7 +86,7 @@ namespace Acceleratio.SPDG.Generator
                 using (PrincipalContext ctx = new PrincipalContext(contextType, domainName))
                 {
                     var searchPrinciple = new UserPrincipal(ctx);
-                    searchPrinciple.EmailAddress = "*";
+                    //searchPrinciple.EmailAddress = "*";
                     searchPrinciple.Enabled = true;
 
                     System.DirectoryServices.AccountManagement.PrincipalSearcher search = new PrincipalSearcher();
@@ -133,7 +133,7 @@ namespace Acceleratio.SPDG.Generator
 
                     foreach (GroupPrincipal groupPrincipal in results)
                     {
-                        retVal.Add(domainName + "\\" + groupPrincipal.Name + ";");
+                        retVal.Add(groupPrincipal.Sid.Value);
                     }                   
                 }
             }

--- a/src/Acceleratio.SPDG.Generator/DataGenerator.cs
+++ b/src/Acceleratio.SPDG.Generator/DataGenerator.cs
@@ -163,11 +163,9 @@ namespace Acceleratio.SPDG.Generator
                     SiteCollInfo siteCollInfo = new SiteCollInfo();
                     siteCollInfo.URL = WorkingDefinition.SiteCollection;
                     WorkingSiteCollections.Add(siteCollInfo);
-                }
-
-                var activeTasks = _tasks.Where(x => x.IsActive);
-                _overallProgressMaxSteps = activeTasks.Count();
-                foreach (var task in activeTasks)
+                } 
+                _overallProgressMaxSteps = _tasks.Count();
+                foreach (var task in _tasks)
                 {
                     if (task.IsActive)
                     {

--- a/src/Acceleratio.SPDG.Generator/GenerationTasks/PermissionsDataGenerationTask.cs
+++ b/src/Acceleratio.SPDG.Generator/GenerationTasks/PermissionsDataGenerationTask.cs
@@ -7,9 +7,9 @@ using Acceleratio.SPDG.Generator.Structures;
 namespace Acceleratio.SPDG.Generator.GenerationTasks
 {
     public abstract class PermissionsDataGenerationTaskBase : DataGenerationTaskBase
-    {       
-        int _permissionsPerObject = 1;        
-        List<SPDGUser> _siteSpUsers = null ;
+    {
+        int _permissionsPerObject = 1;
+        List<SPDGUser> _siteSpUsers = null;
         List<SPDGGroup> _siteSpGroups = null;
         List<SPDGUser> _siteAdGroupSpUsers = null;
 
@@ -114,25 +114,26 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
 
 
         public override void Execute()
-        {                         
+        {
             foreach (SiteCollInfo siteCollInfo in Owner.WorkingSiteCollections)
             {
                 using (var siteColl = Owner.ObjectsFactory.GetSite(siteCollInfo.URL))
                 {
                     _siteSpUsers = new List<SPDGUser>();
                     _siteAdGroupSpUsers = new List<SPDGUser>();
-                    _siteSpGroups=new List<SPDGGroup>();
+                    _siteSpGroups = new List<SPDGGroup>();
 
                     Owner.IncrementCurrentTaskProgress("Ensuring users and groups on '" + siteCollInfo.URL + "'");
                     EnsureUsersAndGroups(siteColl.RootWeb);
 
+                    setSitePermissions(siteColl.RootWeb);
                     foreach (SiteInfo siteInfo in siteCollInfo.Sites)
                     {
                         using (var web = siteColl.OpenWeb(siteInfo.ID))
-                        {                          
-                            Owner.IncrementCurrentTaskProgress("Crawling site",0);
-                            if(_allSitesToHaveUniquePermissions.Contains(siteInfo))
-                            {                             
+                        {
+                            Owner.IncrementCurrentTaskProgress("Crawling site", 0);
+                            if (_allSitesToHaveUniquePermissions.Contains(siteInfo))
+                            {
                                 setSitePermissions(web);
                             }
 
@@ -142,7 +143,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                                 {
                                     Owner.IncrementCurrentTaskProgress("Crawling list " + web.Url + "/" + listInfo.Name, 0);
                                     if (_allListsToHavehUniquePermissions.Contains(listInfo))
-                                    {                                        
+                                    {
                                         setListPermissions(web, listInfo.Name);
                                     }
 
@@ -151,7 +152,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                                         foreach (FolderInfo folderInfo in listInfo.Folders)
                                         {
                                             if (_allFoldersToHaveUniquePermissions.Contains(folderInfo))
-                                            {                                                
+                                            {
                                                 setFolderPermissions(web, folderInfo.URL);
                                             }
                                             Owner.IncrementCurrentTaskProgress("Crawled folder" + web.Url + "/" + listInfo.Name);
@@ -167,7 +168,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                                 }
                             }
 
-                            Owner.IncrementCurrentTaskProgress("Crawled site "+ web.Url);
+                            Owner.IncrementCurrentTaskProgress("Crawled site " + web.Url);
                         }
                     }
                 }
@@ -177,7 +178,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
 
         protected abstract List<string> GetAvailableUsersInDirectory();
         protected abstract List<string> GetAvailableGroupsInDirectory();
-        
+
 
         private void EnsureUsersAndGroups(SPDGWeb web)
         {
@@ -192,7 +193,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
 
                 try
                 {
-                    var user = web.EnsureUser(userName);                                
+                    var user = web.EnsureUser(userName);
                     Log.Write("Ensured user:" + userName + " for site: " + web.Url);
                 }
                 catch (Exception ex)
@@ -213,7 +214,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
 
                 try
                 {
-                    var user = web.EnsureUser(groupName);                                    
+                    var user = web.EnsureUser(groupName);
                     Log.Write("Ensured user:" + groupName + " for site: " + web.Url);
                 }
                 catch (Exception ex)
@@ -221,9 +222,9 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                     Errors.Log(ex);
                     Log.Write("Error adding user:" + groupName);
                 }
-            }          
+            }
 
-            HashSet<string> createdGroups=new HashSet<string>();
+            HashSet<string> createdGroups = new HashSet<string>();
             /// CREATE SHAREPOINT GROUPS            
             if (WorkingDefinition.PermissionsPercentForSPGroups > 0)
             {
@@ -232,7 +233,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                     string nameCandidate = SampleData.GetSampleValueRandom(SampleData.Accounts) + " Group";
                     try
                     {
-                        web.AddSiteGroup(nameCandidate,                        
+                        web.AddSiteGroup(nameCandidate,
                         web.CurrentUser,
                         web.CurrentUser,
                         "SPDG generated group");
@@ -243,7 +244,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                     {
                         Errors.Log(ex);
                     }
-                }                
+                }
             }
             _siteSpGroups = web.SiteGroups.ToList();
             _siteSpUsers = web.SiteUsers.Where(x => !x.IsDomainGroup).ToList();
@@ -277,7 +278,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
             Owner.IncrementCurrentTaskProgress("Adding permissions to site " + web.Url + "'", 0);
             if (!web.HasUniqueRoleAssignments)
             {
-                web.BreakRoleInheritance(true);
+                web.BreakRoleInheritance(false);
             }
             for (int i = 0; i < _permissionsPerObject; i++)
             {
@@ -289,9 +290,9 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                 {
                     Errors.Log(ex);
                 }
-               
+
             }
-            Log.Write("Unique permissions added to site: " + web.Url);            
+            Log.Write("Unique permissions added to site: " + web.Url);
         }
 
         private void setListPermissions(SPDGWeb web, string listName)
@@ -300,12 +301,12 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
             var list = web.GetList(listName);
             if (!list.HasUniqueRoleAssignments)
             {
-                list.BreakRoleInheritance(true);
+                list.BreakRoleInheritance(false);
             }
 
             for (int i = 0; i < _permissionsPerObject; i++)
             {
-                setupNextRoleAssignment(web, list);                
+                setupNextRoleAssignment(web, list);
             }
 
             Owner.IncrementCurrentTaskProgress("Unique permissions added to list: " + listName + ", site: " + web.Url);
@@ -317,36 +318,36 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
             SPDGFolder folder = web.GetFolder(folderURL);
             if (!folder.Item.HasUniqueRoleAssignments)
             {
-                folder.Item.BreakRoleInheritance(true);
+                folder.Item.BreakRoleInheritance(false);
             }
 
             for (int i = 0; i < _permissionsPerObject; i++)
             {
-               setupNextRoleAssignment(web, folder.Item);
+                setupNextRoleAssignment(web, folder.Item);
             }
 
-            Owner.IncrementCurrentTaskProgress("Unique permissions added to folder: " + folderURL + " in site: " + web.Url);            
+            Owner.IncrementCurrentTaskProgress("Unique permissions added to folder: " + folderURL + " in site: " + web.Url);
         }
 
         private void setItemPermissions(SPDGWeb web, string listName)
         {
             var list = web.GetList(listName);
             foreach (var item in list.Items)
-            {                
+            {
                 if (SampleData.GetRandomNumber(1, 100) < WorkingDefinition.PermissionsPercentOfListItems)
                 {
                     Owner.IncrementCurrentTaskProgress("Adding permissions for item/document '" + item.DisplayName + "' in list '" + list.Title, 0);
                     if (!item.HasUniqueRoleAssignments)
                     {
-                        item.BreakRoleInheritance(true);
+                        item.BreakRoleInheritance(false);
                     }
 
                     for (int i = 0; i < _permissionsPerObject; i++)
                     {
-                        setupNextRoleAssignment(web, item);                    
+                        setupNextRoleAssignment(web, item);
                     }
 
-                    Owner.IncrementCurrentTaskProgress("Unique permissions added for item/document '" + item.DisplayName + "' in list '"+list.Title);
+                    Owner.IncrementCurrentTaskProgress("Unique permissions added for item/document '" + item.DisplayName + "' in list '" + list.Title);
                 }
                 else
                 {
@@ -357,10 +358,10 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
 
 
         private void setupNextRoleAssignment(SPDGWeb web, SPDGSecurableObject securableObject)
-        {            
-            SPDGPrincipal principal = null;            
+        {
+            SPDGPrincipal principal = null;
             var rnd = SampleData.GetRandomNumber(0, 100);
-            if (rnd< WorkingDefinition.PermissionsPercentForUsers)
+            if (rnd < WorkingDefinition.PermissionsPercentForUsers)
             {
                 principal = _siteSpUsers[SampleData.GetRandomNumber(0, _siteSpUsers.Count - 1)];
             }
@@ -373,13 +374,15 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                 principal = _siteAdGroupSpUsers[SampleData.GetRandomNumber(0, _siteAdGroupSpUsers.Count - 1)];
             }
 
-            if (securableObject.GetRoleAssignmentByPrincipal(principal) == null)
+            var roleAssignment = securableObject.GetRoleAssignmentByPrincipal(principal);
+
+            if (roleAssignment == null || roleAssignment.RoleDefinitionBindings.All(x => x.IsGuestRole))
             {
-                var availableRoledefinitions = web.RoleDefinitions.Where(x=>!x.IsGuestRole).ToList();
-                
+                var availableRoledefinitions = web.RoleDefinitions.Where(x => !x.IsGuestRole).ToList();
+
                 var selected = availableRoledefinitions[SampleData.GetRandomNumber(0, availableRoledefinitions.Count - 1)];
-                securableObject.AddRoleAssignment(principal, new List<SPDGRoleDefinition> {selected});
+                securableObject.AddRoleAssignment(principal, new List<SPDGRoleDefinition> { selected });
             }
-        } 
+        }
     }
 }


### PR DESCRIPTION
Ensuring AD groups to SharePoint is now done with group's SID. It seems to be safer way, as opposed to using the group name or samAccountName.

Changed the way tasks are chosen to be run. The data generator now checks if each task is active (ready and configured) just before executing. This way the tasks can be lined up in desired order. (in this case, permission task should always run after creating web applications and site collections).

Fixed various problems in PermissionDataGenerationTask