### PR TITLE
F.content type fixes

### DIFF
--- a/src/Acceleratio.SPDG.Generator/DataGenerator.cs
+++ b/src/Acceleratio.SPDG.Generator/DataGenerator.cs
@@ -194,7 +194,7 @@ namespace Acceleratio.SPDG.Generator
 
                 foreach (var site in rootSite.RootWeb.Webs)
                 {
-                    sites.Add(new SiteInfo() { URL = site.Url, ID = site.ID });
+                    sites.AddRange(getSubsites(site));
                 }
 
                 return sites;
@@ -203,7 +203,25 @@ namespace Acceleratio.SPDG.Generator
             {
                 return new List<SiteInfo>();
             }
-        } 
+        }
+
+        private List<SiteInfo> getSubsites(SPDGWeb parentWeb, int maxDepth = 32)
+        {
+            List<SiteInfo> sites = new List<SiteInfo>();
+            sites.Add(new SiteInfo() { URL = parentWeb.Url, ID = parentWeb.ID });
+
+            if (parentWeb.Webs.Count() == 0 || maxDepth == 0)
+            {
+                return sites;
+            }
+
+            foreach (var subsite in parentWeb.Webs)
+            {
+                sites.AddRange(getSubsites(subsite, maxDepth - 1));
+            }
+
+            return sites;
+        }  
 
         private static bool? _supportsClient;
         public static bool SupportsClient

--- a/src/Acceleratio.SPDG.Generator/DataGenerator.cs
+++ b/src/Acceleratio.SPDG.Generator/DataGenerator.cs
@@ -162,6 +162,7 @@ namespace Acceleratio.SPDG.Generator
                 {
                     SiteCollInfo siteCollInfo = new SiteCollInfo();
                     siteCollInfo.URL = WorkingDefinition.SiteCollection;
+                    siteCollInfo.Sites = getSitesForSiteCollection();
                     WorkingSiteCollections.Add(siteCollInfo);
                 } 
                 _overallProgressMaxSteps = _tasks.Count();
@@ -182,9 +183,27 @@ namespace Acceleratio.SPDG.Generator
                 Errors.Log(ex);                
             }
             return false;
-        }        
+        }
 
+        private List<SiteInfo> getSitesForSiteCollection()
+        {
+            try
+            {
+                List<SiteInfo> sites = new List<SiteInfo>();
+                var rootSite = ObjectsFactory.GetSite(WorkingDefinition.SiteCollection);
 
+                foreach (var site in rootSite.RootWeb.Webs)
+                {
+                    sites.Add(new SiteInfo() { URL = site.Url, ID = site.ID });
+                }
+
+                return sites;
+            }
+            catch
+            {
+                return new List<SiteInfo>();
+            }
+        } 
 
         private static bool? _supportsClient;
         public static bool SupportsClient

--- a/src/Acceleratio.SPDG.Generator/GenerationTasks/SitesDataGenerationTask.cs
+++ b/src/Acceleratio.SPDG.Generator/GenerationTasks/SitesDataGenerationTask.cs
@@ -30,7 +30,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
 
         public override bool IsActive
         {
-            get { return true; }
+            get { return !WorkingDefinition.UseOnlyExistingSites; }
         }
 
         internal void CreateSubsites(ref List<SiteInfo> sites, SPDGWeb parentWeb, int currentLevel, int maxLevels, ref int siteCounter, int maxSitesToCreate, string parentBaseName)
@@ -64,7 +64,6 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
         
         public override void Execute()
         {
-            
             foreach (SiteCollInfo siteCollInfo in Owner.WorkingSiteCollections)
             {
                 using (var siteColl = Owner.ObjectsFactory.GetSite(siteCollInfo.URL))
@@ -78,7 +77,7 @@ namespace Acceleratio.SPDG.Generator.GenerationTasks
                     List<SiteInfo> sites = new List<SiteInfo>(); 
                     CreateSubsites(ref sites, siteColl.RootWeb, 0, WorkingDefinition.MaxNumberOfLevelsForSites, ref sitecounter, WorkingDefinition.NumberOfSitesToCreate, "");
                    
-                    siteCollInfo.Sites = sites;
+                    siteCollInfo.Sites.AddRange(sites);
                 }
             }
         }

--- a/src/Acceleratio.SPDG.Generator/GeneratorDefinition.cs
+++ b/src/Acceleratio.SPDG.Generator/GeneratorDefinition.cs
@@ -59,6 +59,7 @@ namespace Acceleratio.SPDG.Generator
         public int CreateNewSiteCollections { get; set; }
         public bool UseExistingSiteCollection { get; set; }
         public string SiteCollection { get; set; }
+        public bool UseOnlyExistingSites { get; set; }
         public int NumberOfSitesToCreate { get; set; }
         public int MaxNumberOfLevelsForSites { get; set; }
         public int MaxNumberOfListsAndLibrariesPerSite { get; set; }

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -12,21 +12,6 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -12,6 +12,21 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Acceleratio.SPDG.UI/frm05Sites.Designer.cs
+++ b/src/Acceleratio.SPDG.UI/frm05Sites.Designer.cs
@@ -37,8 +37,13 @@
             this.lblNumberLevels = new System.Windows.Forms.Label();
             this.cboSiteTemplates = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
+            this.panelSiteOptions = new System.Windows.Forms.Panel();
+            this.chkUseOnlyExistingSites = new System.Windows.Forms.CheckBox();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             ((System.ComponentModel.ISupportInitialize)(this.trackNumSitesToCreate)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackMaxNumberLevels)).BeginInit();
+            this.panelSiteOptions.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnBack
@@ -69,7 +74,7 @@
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.label2.ForeColor = System.Drawing.Color.DarkSlateGray;
-            this.label2.Location = new System.Drawing.Point(265, 155);
+            this.label2.Location = new System.Drawing.Point(16, 12);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(143, 15);
             this.label2.TabIndex = 8;
@@ -78,7 +83,7 @@
             // trackNumSitesToCreate
             // 
             this.trackNumSitesToCreate.LargeChange = 50;
-            this.trackNumSitesToCreate.Location = new System.Drawing.Point(260, 177);
+            this.trackNumSitesToCreate.Location = new System.Drawing.Point(11, 34);
             this.trackNumSitesToCreate.Maximum = 500;
             this.trackNumSitesToCreate.Minimum = 1;
             this.trackNumSitesToCreate.Name = "trackNumSitesToCreate";
@@ -90,7 +95,8 @@
             // trackMaxNumberLevels
             // 
             this.trackMaxNumberLevels.LargeChange = 1;
-            this.trackMaxNumberLevels.Location = new System.Drawing.Point(260, 274);
+            this.trackMaxNumberLevels.Location = new System.Drawing.Point(11, 131);
+            this.trackMaxNumberLevels.Minimum = 1;
             this.trackMaxNumberLevels.Name = "trackMaxNumberLevels";
             this.trackMaxNumberLevels.Size = new System.Drawing.Size(543, 45);
             this.trackMaxNumberLevels.TabIndex = 14;
@@ -102,7 +108,7 @@
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.label3.ForeColor = System.Drawing.Color.DarkSlateGray;
-            this.label3.Location = new System.Drawing.Point(265, 256);
+            this.label3.Location = new System.Drawing.Point(16, 113);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(170, 15);
             this.label3.TabIndex = 13;
@@ -113,7 +119,7 @@
             this.lblNumSites.AutoSize = true;
             this.lblNumSites.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.lblNumSites.ForeColor = System.Drawing.Color.DarkSlateGray;
-            this.lblNumSites.Location = new System.Drawing.Point(818, 181);
+            this.lblNumSites.Location = new System.Drawing.Point(569, 38);
             this.lblNumSites.Name = "lblNumSites";
             this.lblNumSites.Size = new System.Drawing.Size(19, 15);
             this.lblNumSites.TabIndex = 15;
@@ -124,7 +130,7 @@
             this.lblNumberLevels.AutoSize = true;
             this.lblNumberLevels.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.lblNumberLevels.ForeColor = System.Drawing.Color.DarkSlateGray;
-            this.lblNumberLevels.Location = new System.Drawing.Point(819, 277);
+            this.lblNumberLevels.Location = new System.Drawing.Point(570, 134);
             this.lblNumberLevels.Name = "lblNumberLevels";
             this.lblNumberLevels.Size = new System.Drawing.Size(13, 15);
             this.lblNumberLevels.TabIndex = 16;
@@ -133,7 +139,7 @@
             // cboSiteTemplates
             // 
             this.cboSiteTemplates.FormattingEnabled = true;
-            this.cboSiteTemplates.Location = new System.Drawing.Point(268, 371);
+            this.cboSiteTemplates.Location = new System.Drawing.Point(19, 228);
             this.cboSiteTemplates.Name = "cboSiteTemplates";
             this.cboSiteTemplates.Size = new System.Drawing.Size(526, 21);
             this.cboSiteTemplates.TabIndex = 17;
@@ -143,45 +149,70 @@
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.label1.ForeColor = System.Drawing.Color.DarkSlateGray;
-            this.label1.Location = new System.Drawing.Point(265, 347);
+            this.label1.Location = new System.Drawing.Point(16, 204);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(101, 15);
             this.label1.TabIndex = 18;
             this.label1.Text = "Use Site Template";
+            // 
+            // panelSiteOptions
+            // 
+            this.panelSiteOptions.Controls.Add(this.label2);
+            this.panelSiteOptions.Controls.Add(this.label1);
+            this.panelSiteOptions.Controls.Add(this.trackNumSitesToCreate);
+            this.panelSiteOptions.Controls.Add(this.cboSiteTemplates);
+            this.panelSiteOptions.Controls.Add(this.label3);
+            this.panelSiteOptions.Controls.Add(this.lblNumberLevels);
+            this.panelSiteOptions.Controls.Add(this.trackMaxNumberLevels);
+            this.panelSiteOptions.Controls.Add(this.lblNumSites);
+            this.panelSiteOptions.Location = new System.Drawing.Point(3, 26);
+            this.panelSiteOptions.Name = "panelSiteOptions";
+            this.panelSiteOptions.Size = new System.Drawing.Size(620, 321);
+            this.panelSiteOptions.TabIndex = 19;
+            // 
+            // chkUseOnlyExistingSites
+            // 
+            this.chkUseOnlyExistingSites.AutoSize = true;
+            this.chkUseOnlyExistingSites.Location = new System.Drawing.Point(3, 3);
+            this.chkUseOnlyExistingSites.Name = "chkUseOnlyExistingSites";
+            this.chkUseOnlyExistingSites.Size = new System.Drawing.Size(129, 17);
+            this.chkUseOnlyExistingSites.TabIndex = 19;
+            this.chkUseOnlyExistingSites.Text = "Use only existing sites";
+            this.chkUseOnlyExistingSites.UseVisualStyleBackColor = true;
+            this.chkUseOnlyExistingSites.CheckedChanged += new System.EventHandler(this.chkUseOnlyExistingSites_CheckedChanged);
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.chkUseOnlyExistingSites);
+            this.flowLayoutPanel1.Controls.Add(this.panelSiteOptions);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(265, 155);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(633, 383);
+            this.flowLayoutPanel1.TabIndex = 20;
             // 
             // frm05Sites
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(921, 644);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.cboSiteTemplates);
-            this.Controls.Add(this.lblNumberLevels);
-            this.Controls.Add(this.lblNumSites);
-            this.Controls.Add(this.trackMaxNumberLevels);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.trackNumSitesToCreate);
-            this.Controls.Add(this.label2);
+            this.Controls.Add(this.flowLayoutPanel1);
             this.Controls.Add(this.ucSteps1);
             this.Name = "frm05Sites";
             this.Text = "frm05Sites";
+            this.Controls.SetChildIndex(this.ucSteps1, 0);
+            this.Controls.SetChildIndex(this.flowLayoutPanel1, 0);
             this.Controls.SetChildIndex(this.lblTitle, 0);
             this.Controls.SetChildIndex(this.lblDescription, 0);
             this.Controls.SetChildIndex(this.btnBack, 0);
             this.Controls.SetChildIndex(this.btnNext, 0);
             this.Controls.SetChildIndex(this.btnHelp, 0);
             this.Controls.SetChildIndex(this.btnClose, 0);
-            this.Controls.SetChildIndex(this.ucSteps1, 0);
-            this.Controls.SetChildIndex(this.label2, 0);
-            this.Controls.SetChildIndex(this.trackNumSitesToCreate, 0);
-            this.Controls.SetChildIndex(this.label3, 0);
-            this.Controls.SetChildIndex(this.trackMaxNumberLevels, 0);
-            this.Controls.SetChildIndex(this.lblNumSites, 0);
-            this.Controls.SetChildIndex(this.lblNumberLevels, 0);
-            this.Controls.SetChildIndex(this.cboSiteTemplates, 0);
-            this.Controls.SetChildIndex(this.label1, 0);
             ((System.ComponentModel.ISupportInitialize)(this.trackNumSitesToCreate)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackMaxNumberLevels)).EndInit();
+            this.panelSiteOptions.ResumeLayout(false);
+            this.panelSiteOptions.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -198,5 +229,8 @@
         private System.Windows.Forms.Label lblNumberLevels;
         private System.Windows.Forms.ComboBox cboSiteTemplates;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Panel panelSiteOptions;
+        private System.Windows.Forms.CheckBox chkUseOnlyExistingSites;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/src/Acceleratio.SPDG.UI/frm05Sites.cs
+++ b/src/Acceleratio.SPDG.UI/frm05Sites.cs
@@ -23,8 +23,47 @@ namespace Acceleratio.SPDG.UI
             ucSteps1.showStep(5);
             this.Text = Common.APP_TITLE;
 
+            determineChkUseOnlyExistingSitesVisibility();
             initTemplates();
             loadData();
+            determineOptionsStatus();
+        }
+
+        private void determineChkUseOnlyExistingSitesVisibility()
+        {
+            if (Common.WorkingDefinition.UseExistingSiteCollection)
+            {
+                chkUseOnlyExistingSites.Visible = true;
+            }
+            else
+            {
+                chkUseOnlyExistingSites.Visible = false;
+            } 
+        }
+
+        private void determineOptionsStatus()
+        {
+            if (chkUseOnlyExistingSites.Checked)
+            {
+                panelSiteOptions.Enabled = false;
+            }
+            else
+            {
+                panelSiteOptions.Enabled = true;
+            }
+        }
+
+        private bool UseOnlyExistingSites
+        {
+            get
+            {
+                if (!Common.WorkingDefinition.UseExistingSiteCollection)
+                {
+                    return false;
+                }
+
+                return chkUseOnlyExistingSites.Checked;
+            }
         }
 
         void btnBack_Click(object sender, EventArgs e)
@@ -57,6 +96,7 @@ namespace Acceleratio.SPDG.UI
         {
             trackNumSitesToCreate.Value = Common.WorkingDefinition.NumberOfSitesToCreate;
             trackMaxNumberLevels.Value = Common.WorkingDefinition.MaxNumberOfLevelsForSites;
+            chkUseOnlyExistingSites.Checked = Common.WorkingDefinition.UseOnlyExistingSites;
 
             if (!string.IsNullOrEmpty(Common.WorkingDefinition.SiteTemplate))
             {
@@ -68,6 +108,7 @@ namespace Acceleratio.SPDG.UI
         {
             Common.WorkingDefinition.NumberOfSitesToCreate = trackNumSitesToCreate.Value;
             Common.WorkingDefinition.MaxNumberOfLevelsForSites = trackMaxNumberLevels.Value;
+            Common.WorkingDefinition.UseOnlyExistingSites = UseOnlyExistingSites;
 
             if (cboSiteTemplates.SelectedItem != null)
             {
@@ -85,6 +126,11 @@ namespace Acceleratio.SPDG.UI
         private void trackMaxNumberLevels_ValueChanged(object sender, EventArgs e)
         {
             lblNumberLevels.Text = trackMaxNumberLevels.Value.ToString();
+        }
+
+        private void chkUseOnlyExistingSites_CheckedChanged(object sender, EventArgs e)
+        {
+            determineOptionsStatus();
         }
     }
 }

--- a/src/Acceleratio.SPDG.UI/frm05Sites.resx
+++ b/src/Acceleratio.SPDG.UI/frm05Sites.resx
@@ -112,39 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="ucSteps1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="label2.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="trackNumSitesToCreate.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="trackMaxNumberLevels.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="label3.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="lblNumSites.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="lblNumberLevels.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="cboSiteTemplates.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="label1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
 </root>

--- a/src/acceleratio.spdg.generator.server/GenerationTasks/CreateContentTypesGenerationTask.cs
+++ b/src/acceleratio.spdg.generator.server/GenerationTasks/CreateContentTypesGenerationTask.cs
@@ -9,6 +9,9 @@ namespace Acceleratio.SPDG.Generator.Server.GenerationTasks
 {
     class CreateContentTypesGenerationTask : DataGenerationTaskBase
     {
+        private const double _contentTypeGroupModifier = 0.3;
+        private const double _contentTypeListAssignmentModifier = 0.3;
+        private List<string> _contentTypeGroupNames; 
         public override string Title
         {
             get { return "Creating Content Types"; }
@@ -52,7 +55,8 @@ namespace Acceleratio.SPDG.Generator.Server.GenerationTasks
 
         private List<SPContentType> createContentTypesOnRootWeb(SPWeb web)
         {
-            List<SPContentType> newContentTypes = new List<SPContentType>();
+            List<SPContentType> newContentTypes = new List<SPContentType>(); 
+            generateCustomContentTypeGroupNames();
             for (int c = 0; c < WorkingDefinition.MaxNumberOfContentTypesPerSiteCollection; c++)
             {
                 try
@@ -62,7 +66,7 @@ namespace Acceleratio.SPDG.Generator.Server.GenerationTasks
                     SPContentType contentType = new SPContentType(web.ContentTypes["Document"], web.ContentTypes,
                         contentTypeName + " Document");
                     web.ContentTypes.Add(contentType);
-                    contentType.Group = "Custom SPDG Content Types";
+                    contentType.Group = getCustomContentTypeName();
                     contentType.Description = contentTypeName + " content type";
                     List<string> randomSiteColumns = GetRandomSiteColumns();
                     foreach (string siteColumn in randomSiteColumns)
@@ -83,7 +87,7 @@ namespace Acceleratio.SPDG.Generator.Server.GenerationTasks
                             SPContentType childContentType = new SPContentType(contentType, web.ContentTypes,
                                 contentTypeName + " Document");
                             web.ContentTypes.Add(childContentType);
-                            childContentType.Group = "Custom SPDG Content Types";
+                            childContentType.Group = getCustomContentTypeName();
                             childContentType.Description = contentTypeName + " content type";
                             randomSiteColumns = GetRandomSiteColumns();
                             foreach (string siteColumn in randomSiteColumns)
@@ -123,7 +127,7 @@ namespace Acceleratio.SPDG.Generator.Server.GenerationTasks
 
                             foreach (SPContentType contentType in _newContentTypes)
                             {
-                                for (int i = 0; i < (listCount/3); i++)
+                                for (int i = 0; i < (listCount * _contentTypeListAssignmentModifier); i++)
                                 {
                                     var listIndex = SampleData.GetRandomNumber(0, listCount);
                                     if (!web.Lists[listIndex].ContentTypesEnabled)
@@ -144,8 +148,37 @@ namespace Acceleratio.SPDG.Generator.Server.GenerationTasks
             }
         }
 
-        private
-            string findAvailableContentTypeName(SPWeb web)
+        private string getCustomContentTypeName()
+        {
+            int index = SampleData.GetRandomNumber(0, _contentTypeGroupNames.Count);
+            return _contentTypeGroupNames[index];
+        }
+
+        private void generateCustomContentTypeGroupNames()
+        {
+            _contentTypeGroupNames = new List<string>();
+            int numberOfGroups = Convert.ToInt32(Math.Ceiling(WorkingDefinition.MaxNumberOfContentTypesPerSiteCollection*_contentTypeGroupModifier));
+            for (int i = 0; i < numberOfGroups; i++)
+            {
+                _contentTypeGroupNames.Add(findAvailableContentTypeGroupName());
+            }
+        }
+
+        private string findAvailableContentTypeGroupName()
+        {
+            string candidate = SampleData.GetSampleValueRandom(SampleData.BusinessDocsTypes) + " Group";
+            
+            if (_contentTypeGroupNames.Contains(candidate))
+            {
+                return findAvailableContentTypeGroupName();
+            }
+            else
+            {
+                return candidate;
+            }
+        }
+
+        private string findAvailableContentTypeName(SPWeb web)
         {
             string candidate = SampleData.GetSampleValueRandom(SampleData.BusinessDocsTypes);
             bool alreadyExists = false;

--- a/src/acceleratio.spdg.generator.server/GenerationTasks/CreateContentTypesGenerationTask.cs
+++ b/src/acceleratio.spdg.generator.server/GenerationTasks/CreateContentTypesGenerationTask.cs
@@ -35,6 +35,7 @@ namespace Acceleratio.SPDG.Generator.Server.GenerationTasks
         public override void Execute()
         {
             CreateContentTypes();
+            AddCustomContentTypesToLists();           
         }
 
         public void CreateContentTypes()
@@ -100,7 +101,47 @@ namespace Acceleratio.SPDG.Generator.Server.GenerationTasks
             }
         }
 
-        private string findAvailableContentTypeName(SPWeb web)
+        public void AddCustomContentTypesToLists()
+        {
+            foreach (SiteCollInfo siteCollInfo in Owner.WorkingSiteCollections)
+            {
+                using (SPSite siteColl = new SPSite(siteCollInfo.URL))
+                {
+                    foreach (SiteInfo siteInfo in siteCollInfo.Sites)
+                    {
+                        using (SPWeb web = siteColl.OpenWeb(siteInfo.ID))
+                        {
+                            int listCount = web.Lists.Count;
+                            if (listCount == 0)
+                            {
+                                continue;
+                            }
+
+                            foreach (SPContentType contentType in web.ContentTypes)
+                            {
+                                for (int i = 0; i < (listCount/3); i++)
+                                {
+                                    var listIndex = SampleData.GetRandomNumber(0, listCount);
+                                    if (!web.Lists[listIndex].ContentTypesEnabled)
+                                    {
+                                        continue;
+                                    }
+
+                                    if (web.Lists[listIndex].ContentTypes[contentType.Name] == null)
+                                    {
+                                        web.Lists[listIndex].ContentTypes.Add(contentType);
+                                    }
+                                }
+                            }
+                                                        
+                        }
+                    }
+                }
+            }
+        }
+
+        private
+            string findAvailableContentTypeName(SPWeb web)
         {
             string candidate = SampleData.GetSampleValueRandom(SampleData.BusinessDocsTypes);
             bool alreadyExists = false;


### PR DESCRIPTION
-added loading of all sites if use existing site collection option was chosen
-content types are now created on root web for each site collection and then added to random lists on all
sites
-added an options on Sites tab of wizard to use only existing sites (only visible if use existing site collection option was chosen)